### PR TITLE
Sort improper irony examples first

### DIFF
--- a/is-it-irony/src/App.tsx
+++ b/is-it-irony/src/App.tsx
@@ -296,6 +296,9 @@ export default function App() {
         if (!hay.includes(q)) return false;
       }
       return true;
+    }).sort((a, b) => {
+      if (a.proper === b.proper) return 0;
+      return a.proper ? 1 : -1;
     });
   }, [query, show, activeTypes]);
 


### PR DESCRIPTION
## Summary
- sort filtered examples so improper cards appear at the top

## Testing
- `npm test` (fails: Missing script)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ae6a67fde4832a8b729cb162cf2eba